### PR TITLE
Ruby & NodeJS fix epoch

### DIFF
--- a/nodeJS/mvCore.js
+++ b/nodeJS/mvCore.js
@@ -9,9 +9,9 @@ const mvOconv = (value, rule) => {
   twoLetterRule = upcasedRule.substring(0, 2);
 
   if (oneLetterRule === "D") {
-    return mvOconvDate(value, upcasedRule);
+    return mvOconvDate(Number.parseInt(value), upcasedRule);
   } else if (twoLetterRule === "MT") {
-    return mvOconvTime(value, upcasedRule);
+    return mvOconvTime(Number.parseInt(value), upcasedRule);
   } else if (oneLetterRule === "G") {
     return mvOconvGroup(value, upcasedRule);
   }
@@ -53,7 +53,7 @@ const mvOconvTime = (value, rule) => {
 };
 
 const mvOconvDate = (value, rule) => {
-  const mvEpoch = new Date(1969, 0, 1);
+  const mvEpoch = new Date(1967, 11, 31);
   let date = mvEpoch.addDays(value);
 
   if (/D[1234][-\/]/.test(rule)) {

--- a/nodeJS/test.js
+++ b/nodeJS/test.js
@@ -13,7 +13,7 @@ const stackData = require("fs")
 tests = stackData.split("^");
 for (test of tests) {
   const [value, rule, expected] = test.split("]");
-  const result = mvOconv(Number.parseInt(value), rule);
+  const result = mvOconv(value, rule);
   console.log(
     `mv_oconv(${value}, "${rule}") - Expected: '${expected}' - Actual: '${result}'`
   );
@@ -21,11 +21,11 @@ for (test of tests) {
 
 console.log("");
 console.log("Hardcoded Cases");
-console.log(mvOconv(18500, "D2/")); // 08/27/19
-console.log(mvOconv(18500, "D4-")); // 08-27-2019
+console.log(mvOconv(18500, "D2/")); // 08/25/18
+console.log(mvOconv(18500, "D4-")); // 08-25-2018
 console.log(mvOconv(18500, "DM")); // 08
-console.log(mvOconv(18500, "DD")); // 27
-console.log(mvOconv(18500, "D2Y")); // 19
+console.log(mvOconv(18500, "DD")); // 25
+console.log(mvOconv(18500, "D2Y")); // 18
 console.log(mvOconv(86375, "MTS")); // 23:59:35
 console.log(mvOconv(86375, "MTHS")); // 11:59:35PM
 console.log(mvOconv("A!BB!CCC!DDD!DDD", "G1!3")); // BB,CCC,DDD

--- a/ruby/mv_core.rb
+++ b/ruby/mv_core.rb
@@ -10,11 +10,11 @@ def mv_oconv(value, rule)
   one_letter_rule = upcased_rule[0]
   two_letter_rule = upcased_rule[0..1] # get the first two letters using a range
   if one_letter_rule == "D" # its a date
-    result = mv_oconv_date(value, upcased_rule)
+    result = mv_oconv_date(value.to_i, upcased_rule)
   elsif one_letter_rule == "G" # its a group
     result = mv_oconv_group(value, upcased_rule)
   elsif two_letter_rule == "MT" # its a time
-    result = mv_oconv_time(value, upcased_rule)
+    result = mv_oconv_time(value.to_i, upcased_rule)
   else
     result = nil
   end

--- a/ruby/mv_core.rb
+++ b/ruby/mv_core.rb
@@ -22,8 +22,8 @@ def mv_oconv(value, rule)
 end
 
 def mv_oconv_date(value, rule)
-  # create a date starting from 1/1/1969 and add value (days) to it
-  date = Date.new(1969,1,1) + value
+  # create a date starting from 12/31/1967 and add value (days) to it
+  date = Date.new(1967,12,31) + value
 
   case rule
   when "DM"

--- a/ruby/test.rb
+++ b/ruby/test.rb
@@ -11,7 +11,7 @@ stack_data = file_data = file.read.chomp
 tests = stack_data.split("^")
 tests.each do |test|
   params = test.split("]")
-  value = params[0].to_i
+  value = params[0]
   rule = params[1]
   expected = params[2]
   puts "mv_oconv(#{value}, \"#{rule}\") - Expected: '#{expected}' - Actual: '#{mv_oconv(value, rule)}'"

--- a/ruby/test.rb
+++ b/ruby/test.rb
@@ -20,11 +20,11 @@ puts ""
 
 # Run some pre-set cases
 puts "Hardcoded Cases"
-puts mv_oconv(18500,'D2/') # 08/27/19
-puts mv_oconv(18500,'D4-') # 08-27-2019
+puts mv_oconv(18500,'D2/') # 08/25/18
+puts mv_oconv(18500,'D4-') # 08-25-2018
 puts mv_oconv(18500,'DM') # 08
-puts mv_oconv(18500,'DD') # 27
-puts mv_oconv(18500,'D2Y') # 19
+puts mv_oconv(18500,'DD') # 25
+puts mv_oconv(18500,'D2Y') # 18
 puts mv_oconv(86375,'MTS') # 23:59:35
 puts mv_oconv(86375,'MTHS') # 11:59:35pm
 puts mv_oconv('A!BB!CCC!DDD!DDD','G1!3') # ["BB", "CCC", "DDD"]


### PR DESCRIPTION
1. Fix the epoch date for both Ruby and NodeJS
2. Fix the comments in test.rb and test.js
3. Fix the assumption that inputs will always be a number when needed in both NodeJS and Ruby